### PR TITLE
在庫数が0の際にnullが登録されていたので修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -419,7 +419,9 @@ class ConfigController extends AbstractController
                     } elseif ($column == 'delivery_fee') {
                         $value[$column] = isset($data['delivery_fee']) ? $data['delivery_fee'] : null;
                     } elseif ($column == 'stock') {
-                        $value[$column] = !empty($data['stock']) ? $data['stock'] : null;
+                        $value[$column] = isset($data['stock']) && $data['stock'] !== ''
+                            ? $data['stock']
+                            : null;
 
                         // dtb_product_stock
                         // todo 2.4系の場合、データが足りない

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -974,6 +974,9 @@ class ConfigController extends AbstractController
                         if ($data['status'] == 2) {
                             $value[$column] = 4;
                         }
+                        if ($data['status'] == '') {
+                            $value[$column] = 3;
+                        }
                     } elseif ($column == 'postal_code') {
                         $value[$column] = mb_substr(mb_convert_kana($data['zip01'].$data['zip02'], 'a'), 0, 8);
                         if (empty($value[$column])) {


### PR DESCRIPTION
2.11系のデータ移行時に発生した問題を修正しています。

- 在庫数が0の際にnullで登録されていたので修正
- 受注ステータスが空の場合に注文取消しで登録するように修正
