### PR TITLE
dtb_order_item.tax_adjustに値を設定するように修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -1120,6 +1120,7 @@ class ConfigController extends AbstractController
                         $value['rounding_type_id'] = 1;
                         $value['tax_type_id'] = 1;
                         $value['tax_display_type_id'] = 1;
+                        $value['tax_adjust'] = 0;
 
                         $value['tax_rule_id'] = isset($data['tax_rule']) ? $data['tax_rule'] : NULL;
 
@@ -1211,6 +1212,7 @@ class ConfigController extends AbstractController
                 $data['price'] = $value;
                 $data['tax'] = 0;
                 $data['tax_rate'] = 0;
+                $data['tax_adjust'] = 0;
                 $data['quantity'] = 1;
                 $data['id'] = $i;
                 if (isset($this->shipping_id[$order_id][0])) {


### PR DESCRIPTION
ec-cube 4.0.3で、dtb_order_itemにtax_adjustが追加された影響で、プラグイン実行時に not null violation が発生していました。

https://github.com/EC-CUBE/ec-cube/pull/4276

tax_adjustが実際に利用されているケースはあまり無いかと思いますので、固定値で0を設定しています。