### PR TITLE
商品明細の税額に誤りがあったので修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -878,12 +878,12 @@ class ConfigController extends AbstractController
             if (!isset($this->product_class_id)) {
                 sleep(5);
             }
+            // todo 商品別税率設定
+            $this->saveToO($em, $csvDir, 'dtb_tax_rule', null, true); // 税率0にしている場合がある
+
             // todo ダウンロード販売の処理
             $this->saveToO($em, $csvDir, 'dtb_order_detail', 'dtb_order_item', true);
             //$this->saveToO($em, $csvDir, 'dtb_shipment_item', 'dtb_order_item');
-
-            // todo 商品別税率設定
-            $this->saveToO($em, $csvDir, 'dtb_tax_rule', null, true); // 税率0にしている場合がある
 
             if (!empty($this->order_item)) {
                 $this->saveOrderItem($em);
@@ -1179,8 +1179,17 @@ class ConfigController extends AbstractController
                             $value['product_class_id'] = $this->product_class_id[$data['product_id']][$data['classcategory_id1']][$data['classcategory_id2']];
                         }
 
-                        if (!empty($data['price']) && !empty($data['tax_rate']) && !empty($data['quantity'])) {
-                            $value['tax'] = round($data['price'] * $data['tax_rate'] / 100) * $data['quantity'];
+                        if (isset($data['price']) && isset($data['tax_rate'])) {
+                            if ($value['rounding_type_id'] == 2) {
+                                $round = 'floor';
+                            } elseif ($data['rounding_type_id'] == 3) {
+                                $round = 'ceil';
+                            } else {
+                                $round = 'round';
+                            }
+                            $value['tax'] = $round($data['price'] * $data['tax_rate'] / 100);
+                        } else {
+                            $value['tax'] = 0;
                         }
 
                         $value['order_item_type_id'] = 1; // 商品で固定する


### PR DESCRIPTION
## 修正内容
- dtb_order_item.taxの値が、個数分登録されていたので修正
- 合わせて丸め処理を行うように修正

## 明細の税額について

誤

| price | quantity | tax | tax_rate |
| -- | -- | -- | -- |
| 100 | 3 | 24 | 8 |

正

price | quantity | tax | tax_rate
-- | -- | -- | --
100 | 3 | 8 | 8

