### PR TITLE
削除済商品がある場合に、商品検索でエラーが発生する問題を修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -892,6 +892,9 @@ class ConfigController extends AbstractController
             // 支払いは基本移行しない
             $em->exec('DELETE FROM dtb_payment_option');
 
+            // 削除済み商品を4系のデータ構造に合わせる
+            $this->fixDeletedProduct($em);
+
             if ($platform == 'mysql') {
                 $em->exec('SET FOREIGN_KEY_CHECKS = 1;');
             } else {
@@ -1182,7 +1185,7 @@ class ConfigController extends AbstractController
                         if (isset($data['price']) && isset($data['tax_rate'])) {
                             if ($value['rounding_type_id'] == 2) {
                                 $round = 'floor';
-                            } elseif ($data['rounding_type_id'] == 3) {
+                            } elseif ($value['rounding_type_id'] == 3) {
                                 $round = 'ceil';
                             } else {
                                 $round = 'round';
@@ -1367,5 +1370,17 @@ class ConfigController extends AbstractController
         }
 
         return array_values($this->tax_rule)[0];
+    }
+
+    private function fixDeletedProduct($em)
+    {
+        $sql = 'UPDATE dtb_product_class SET visible = true WHERE id IN (
+SELECT 
+t1.id AS product_class_id
+FROM dtb_product_class AS t1
+LEFT JOIN dtb_product AS t2 on t1.product_id = t2.id
+WHERE t2.product_status_id = 3 AND t1.visible = false
+)';
+        $em->exec($sql);
     }
 }

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -307,6 +307,9 @@ class ConfigController extends AbstractController
             // 画像の移行はしない
             $em->exec('DELETE FROM dtb_product_image');
 
+            // 削除済み商品を4系のデータ構造に合わせる
+            $this->fixDeletedProduct($em);
+
             // リレーションエラーになるので
             $em->exec('DELETE FROM dtb_cart');
             $em->exec('DELETE FROM dtb_cart_item');
@@ -891,9 +894,6 @@ class ConfigController extends AbstractController
 
             // 支払いは基本移行しない
             $em->exec('DELETE FROM dtb_payment_option');
-
-            // 削除済み商品を4系のデータ構造に合わせる
-            $this->fixDeletedProduct($em);
 
             if ($platform == 'mysql') {
                 $em->exec('SET FOREIGN_KEY_CHECKS = 1;');


### PR DESCRIPTION
## 概要
削除済み商品がある場合、データ移行後、以下の画面でエラーが発生します。

商品一覧画面
詳細検索で、公開ステータスに「廃止」を追加して検索
```
An exception has been thrown during the rendering of a template ("Warning: min(): Array must contain at least one element") 
```

受注登録画面
商品検索モーダルで検索時
```
search product failed.
```
(内部的にはDoctrine のNo Result Exceptionが発生しています)

## 原因

2系で削除済み商品がある場合、レコードは以下のようになります。

dtb_product

product_id | del_flg
-- | --
1 | 1
2 | 1

dtb_product_class

product_class_id | product_id | del_flg | --
-- | -- | -- | --
1 | 1 | 1 |  
2 | 2 | 1 | ※規格ありの場合、1件はダミーレコード
3 | 2 | 1 |  
4 | 2 | 1 |  

4系のテーブルへ移行される際、以下のように変換されます。

dtb_product

id | product_status_id
-- | --
1 | 3 (※廃止ステータスに変換)
2 | 3

dtb_product_class

id | product_id | visible | --
-- | -- | -- | --
1 | 1 | false |  
2 | 2 | false | ※規格ありの場合、1件はダミーレコード
3 | 2 | false |  
4 | 2 | false |  

4系では、廃止ステータスの商品でも、規格がすべてvisible=falseの商品が許容されないので、今回のエラーが発生していたようです。

## 修正

廃止ステータスの商品は規格のvisibleはtrueに更新するようにしています。
規格あり商品の場合は、正確にはダミーレコードがvisible=falseにすべきですが、判別できないのと、廃止商品を復旧させることはほぼないはずなので、いったんこの形で修正しています。

## その他

税率の修正でコミット漏れがあったので、ついでに。。。
```
} elseif ($value['rounding_type_id'] == 3) {
```