### PR TITLE
会員と受注のみ移行するオプションを追加

### DIFF
--- a/Form/Type/Admin/ConfigType.php
+++ b/Form/Type/Admin/ConfigType.php
@@ -3,6 +3,7 @@
 namespace Plugin\DataMigration4\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -27,6 +28,9 @@ class ConfigType extends AbstractType
                         'mimeTypesMessage' => 'zipファイル、tarファイル、tar.gzファイルのいずれかをアップロードしてください。',
                     ]),
                 ],
+            ])->add('customer_order_only', CheckboxType::class, [
+                'label' => '会員と受注データのみ移行する',
+                'required' => false,
             ])
             ;
     }

--- a/Form/Type/Admin/ConfigType.php
+++ b/Form/Type/Admin/ConfigType.php
@@ -29,7 +29,7 @@ class ConfigType extends AbstractType
                     ]),
                 ],
             ])->add('customer_order_only', CheckboxType::class, [
-                'label' => '会員と受注データのみ移行する',
+                'label' => '会員と受注データのみ移行する(一度データ移行を実施している必要があります)',
                 'required' => false,
             ])
             ;

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -94,7 +94,7 @@ file that was distributed with this source code.
                                 <div class="col">
                                     <div class="form-check">
                                         <input type="checkbox" id="{{ form.customer_order_only.vars.id }}" name="{{ form.customer_order_only.vars.full_name }}" class="form-check-input" value="1" />
-                                        <label class="form-check-label" for="{{ form.customer_order_only.vars.id }}">会員と受注データのみ移行する</label>
+                                        <label class="form-check-label" for="{{ form.customer_order_only.vars.id }}">{{ form.customer_order_only.vars.label }}</label>
                                         <i data-tooltip="true"
                                            data-placement="top"
                                            data-original-title="このオプションを利用するには、一度全データが移行されている必要があります。新サイトの構築期間中に、旧サイトで発生した会員や受注データを取り込みたい場合に使用してください" class="fa fa-question-circle fa-lg ml-1"></i>

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -80,14 +80,26 @@ file that was distributed with this source code.
                             </dl>
                         </div>
                         <div id="ex-csv_product-upload" class="card-body">
-                            <div class="row">
+                            <div class="row mb-3">
                                 <div class="col-2"><span>バックアップファイル</span></div>
                                 <div class="col">
                                         {{ form_widget(form.import_file, {'attr': {'accept': 'application/zip,application/x-tar,application/x-gzip'}}) }}
                                         {{ form_errors(form.import_file) }}
                                         <br/>
                                         <button class="btn btn-ec-conversion" type="submit" id="upload-button">Upload</button> (最大 {{ max_upload_size }})
-                                    </form>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-2"><span>オプション</span></div>
+                                <div class="col">
+                                    <div class="form-check">
+                                        <input type="checkbox" id="{{ form.customer_order_only.vars.id }}" name="{{ form.customer_order_only.vars.full_name }}" class="form-check-input" value="1" />
+                                        <label class="form-check-label" for="{{ form.customer_order_only.vars.id }}">会員と受注データのみ移行する</label>
+                                        <i data-tooltip="true"
+                                           data-placement="top"
+                                           data-original-title="このオプションを利用するには、一度全データが移行されている必要があります。新サイトの構築期間中に、旧サイトで発生した会員や受注データを取り込みたい場合に使用してください" class="fa fa-question-circle fa-lg ml-1"></i>
+                                    </div>
+                                    {{ form_errors(form.customer_order_only ) }}
                                 </div>
                             </div>
                         </div>
@@ -112,3 +124,5 @@ file that was distributed with this source code.
         </div>
     </form>
 {% endblock %}
+
+


### PR DESCRIPTION
## 概要

会員と受注のみを移行できるオプションを追加しました。 refs #9 

既存のデータは残し、以下のテーブルのみ移行します。商品データ等は事前に移行されている必要があります。

- dtb_customer
- dtb_other_deliv
- dtb_order
- dtb_shipping
- dtb_mail_history
- dtb_order_detail
