### PR TITLE
dtb_order.message移行の文字数をEC CUBE 4の仕様通り4000字に制限

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -1195,6 +1195,8 @@ class ConfigController extends AbstractController
                         if ($data['status'] == '') {
                             $value[$column] = 3;
                         }
+                    } elseif ($column == 'message') {
+                        $value[$column] = mb_substr($data[$column], 0, 4000);
                     } elseif ($column == 'postal_code') {
                         $value[$column] = mb_substr(mb_convert_kana($data['zip01'].$data['zip02'], 'a'), 0, 8);
                         if (empty($value[$column])) {

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -1195,7 +1195,7 @@ class ConfigController extends AbstractController
                         if ($data['status'] == '') {
                             $value[$column] = 3;
                         }
-                    } elseif ($column == 'message') {
+                    } elseif ($column == 'message' || $column == 'note') {
                         $value[$column] = mb_substr($data[$column], 0, 4000);
                     } elseif ($column == 'postal_code') {
                         $value[$column] = mb_substr(mb_convert_kana($data['zip01'].$data['zip02'], 'a'), 0, 8);


### PR DESCRIPTION
### dtb_order.messageの型

* EC CUBE 2 では `text` （文字列長に制限がない）
  * https://github.com/EC-CUBE/ec-cube2/blob/master/html/install/sql/create_table_mysqli.sql#L530
  * https://github.com/EC-CUBE/ec-cube2/blob/master/html/install/sql/create_table_pgsql.sql#L530
* EC CUBE 4 では `varchar(4000)` （文字列長は4000字まで）
  * https://github.com/EC-CUBE/ec-cube/blob/4.0/src/Eccube/Entity/Order.php#L266

### 修正内容

* 以上の差異により `dtb_order.message` に4000字を超えるデータが存在した場合は変換に失敗する。この問題の修正。
  他の text -> varchar(n) の変換箇所の実装に倣い制限文字数でトリムすることでエラーを回避。
* `dtb_order.note` へも同様の対応