### PR TITLE
３系からの移行で受注に送料が登録されない問題の修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -1165,8 +1165,13 @@ class ConfigController extends AbstractController
                 }
 
                 // 3の差を埋める
-                if ($this->flag_3 && isset($data['delivery_id'])) {
-                    $data['deliv_id'] = $data['delivery_id'];
+                if ($this->flag_3) {
+                    if (isset($data['delivery_id'])) {
+                        $data['deliv_id'] = $data['delivery_id'];
+                    }
+                    if ('dtb_order' === $tableName && isset($data['delivery_fee_total'])) {
+                        $data['deliv_fee'] = $data['delivery_fee_total'];
+                    }
                 }
 
                 // Schemaにあわせた配列を作成する


### PR DESCRIPTION
## 問題
#57 ３系で受注に送料が移行されない

## 修正内容
３系の送料合計カラム名がdtb_order.delivery_fee_totalなので、移行されるようにデータをセットする。