### PR TITLE
.c-conversionAreaのリンククラス名の修正

### DIFF
--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -112,7 +112,7 @@ file that was distributed with this source code.
                 <div class="row justify-content-between align-items-center">
                     <div class="col-6">
                         <div class="c-conversionArea__leftBlockItem">
-                            <a class="c-beseLink"
+                            <a class="c-baseLink"
                                href="{{ url('admin_store_plugin') }}">
                                 <i class="fa fa-backward" aria-hidden="true"></i>
                                 <span>back</span>


### PR DESCRIPTION
移行実行画面のフッターのリンクが水色になっていたので微修正