### PR TITLE
MySQLのためにdelete文サブクエリの修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -429,10 +429,10 @@ class ConfigController extends AbstractController
             $em->exec('UPDATE dtb_product_class SET class_category_id2 = NULL WHERE class_category_id2 not in (select id from dtb_class_category)');
 
             $em->exec('delete from dtb_product_tag where id in (
-                select t1.id from dtb_product_tag t1 left join dtb_tag t2 on t1.tag_id = t2.id where t2.id is null
+                select id from (select t1.id from dtb_product_tag t1 left join dtb_tag t2 on t1.tag_id = t2.id where t2.id is null) as tmp
             );');
             $em->exec('delete from dtb_product_tag where id in (
-                select t1.id from dtb_product_tag t1 left join dtb_product t2 on t1.product_id = t2.id where t2.id is null
+                select id from (select t1.id from dtb_product_tag t1 left join dtb_product t2 on t1.product_id = t2.id where t2.id is null) as tmp
             );');
 
             if ($platform == 'mysql') {


### PR DESCRIPTION
## 問題
MySQLで実行すると下記のエラーが発生する(ポスグレでは起きなかった）

> An exception occurred while executing 'delete from dtb_product_tag where id in (
select t1.id from dtb_product_tag t1 left join dtb_tag t2 on t1.tag_id = t2.id where t2.id is null
);':
>
>SQLSTATE[HY000]: General error: 1093 You can't specify target table 'dtb_product_tag' for update in FROM clause

## 修正
DELETE文のサブクエリの修正

## 環境
現在のHEADで発生　環境は用意されているDockerFileでのMySQL環境