### PR TITLE
３系から移行の支払方法利用条件修正

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -1271,12 +1271,21 @@ class ConfigController extends AbstractController
                     // --> payment
                     } elseif ($column == 'fixed') {
                         $value[$column] = 1;
-                    } elseif ($column == 'rule_max') { // 2.13
-                        $value[$column] = !empty($data['upper_rule']) ? $data['upper_rule'] : null;
-                    } elseif ($column == 'rule_min') { // 2.13
-                        $value[$column] = !empty($data['rule_max']) ? $data['rule_max'] :
-                            (!empty($data['rule']) ? $data['rule'] : null ) ;
-
+                    } elseif ($column == 'rule_max') {
+                        if ($this->flag_3) {
+                            $value[$column] = isset($data['rule_max']) && strlen($data['rule_max']) > 0 ? $data['rule_max'] : null;
+                        } else {
+                            // 2.13
+                            $value[$column] = !empty($data['upper_rule']) ? $data['upper_rule'] : null;
+                        }
+                    } elseif ($column == 'rule_min') {
+                        if ($this->flag_3) {
+                            $value[$column] = isset($data['rule_min']) && strlen($data['rule_min']) > 0 ? $data['rule_min'] : null;
+                        } else {
+                            // 2.13
+                            $value[$column] = !empty($data['rule_max']) ? $data['rule_max'] :
+                                (!empty($data['rule']) ? $data['rule'] : null ) ;
+                        }
                     // --> dtb_order_item
                     } elseif ($column == 'class_category_name1') {
                         $value[$column] = isset($data['classcategory_name1']) && strlen($data['classcategory_name1']) > 0 ? $data['classcategory_name1'] : null;


### PR DESCRIPTION
## 問題
３系からの移行時に支払方法利用条件が下記のように移行される

上限金額 → 全てNULLになる
下限金額 → ３系の上限金額が登録される

## 修正
３系ではdtb_paymentにrule_max、rule_minがあるのでそのまま登録する