### PR TITLE
３系から移行時に商品情報の「検索キーワード」を移行

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -539,6 +539,9 @@ class ConfigController extends AbstractController
                     if (isset($data['description_detail'])) {
                         $data['main_comment'] = $data['description_detail'];
                     }
+                    if (isset($data['search_word'])) {
+                        $data['comment3'] = $data['search_word'];
+                    }
                 }
 
                 // Schemaにあわせた配列を作成する


### PR DESCRIPTION
３系からの移行時

商品情報の検索キーワード(dtb_product.search_word)が移行されていなかったため、移行されるように修正