### PR TITLE
EC-CUBE 4.1 対応

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,10 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, xml, ctype, iconv, mysql, intl, zip, pgsql
-          tools: composer:v1
+          tools: composer:v2
+
+      - if: matrix.eccube-versions == '4.0'
+        run: sudo composer selfupdate --1
 
       - name: Get composer cache directory
         id: composer-cache
@@ -73,8 +76,12 @@ jobs:
       - name: Install Composer dependencies
         run : |
           composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
-          composer require --dev kiy0taka/eccube4-test-fixer
           composer require pear/pear-core-minimal:^1.10.10 pear/archive_tar:^1.4.13 wapmorgan/unified-archive:^1.1.1 nobuhiko/bulk-insert-query
+
+      - name: Install Composer eccube4-test-fixer
+        if: matrix.eccube-versions == '4.0'
+        run : |
+          composer require --dev kiy0taka/eccube4-test-fixer
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,7 +109,7 @@ jobs:
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
 
-      - name: Run Tests
+      - name: Run Tests for EC-CUBE4.1
         if: matrix.eccube-versions != '4.0'
         run: |
           bin/phpunit app/Plugin/$PLUGIN_NAME/Tests

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -284,7 +284,13 @@ class ConfigController extends AbstractController
 
             $listTableColumns = [];
             foreach ($columns as $column) {
-                $listTableColumns[] = $column->getName();
+                $columnName = $column->getName();
+                if ($tableName === 'dtb_member') {
+                    if ($columnName === 'two_factor_auth_key' || $columnName === 'two_factor_auth_enabled') {
+                        continue;
+                    }
+                }
+                $listTableColumns[] = $columnName;
             }
 
             $builder = new BulkInsertQuery($em, $tableName);

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,10 @@
 {
-    "name": "ec-cube/DataMigration4",
-    "version": "2.1.0",
+    "name": "ec-cube/datamigration4",
+    "version": "4.1.0",
     "description": "データ移行プラグイン",
     "type": "eccube-plugin",
-    "repositories": [
-        {
-            "type": "pear",
-            "url": "http://pear.php.net/"
-        }
-    ],
     "require": {
-        "ec-cube/plugin-installer": "~0.0.8",
+        "ec-cube/plugin-installer": "~0.0.8 || ^2.0",
         "pear/pear-core-minimal" : "^1.10.10",
         "pear/archive_tar" : "^1.4.13",
         "wapmorgan/unified-archive": "^1.1.1",


### PR DESCRIPTION
データ移行プラグインの、EC-CUBE4.1対応です

- composer.json のアップデート
- EC-CUBE 4.1 での `dtb_member` テーブルの追加フィールド(二要素認証関連) の移行をスキップ
- GitHub Actions でのユニットテストの実行、4.0 と 4.1 の両対応

(プラグインのバージョン番号はいったん 4.1.0 としましたが、特に根拠のある番号ではないので、ご意見あればください)
